### PR TITLE
add AppSettings model; add createdAt field to models;

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		0AF64FA524475BC30018D070 /* SafariViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF64FA424475BC30018D070 /* SafariViewController.swift */; };
 		0AF6500A24485E450018D070 /* Identicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF6500924485E450018D070 /* Identicon.swift */; };
 		0AF6501B24488D280018D070 /* FullSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF6501A24488D280018D070 /* FullSize.swift */; };
+		551DDEE9244F183500C719D3 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551DDEE8244F183500C719D3 /* AppSettings.swift */; };
+		551DDEEE244F19AE00C719D3 /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551DDEED244F19AE00C719D3 /* CoreDataTestCase.swift */; };
+		551DDEF0244F1A0A00C719D3 /* SafeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551DDEEF244F1A0A00C719D3 /* SafeTests.swift */; };
+		551DDEF2244F1B9800C719D3 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551DDEF1244F1B9800C719D3 /* AppSettingsTests.swift */; };
 		5532D4932448A1960067505A /* Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5532D4922448A1960067505A /* Safe.swift */; };
 		5532D4BA2449A17D0067505A /* CrashlyticsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5532D4AF2449A17D0067505A /* CrashlyticsProtocol.swift */; };
 		5532D4BB2449A17D0067505A /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5532D4B02449A17D0067505A /* Logger.swift */; };
@@ -106,6 +110,10 @@
 		1B81E8C8DC80D2C573D9B6BF /* libPods-MultisigTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MultisigTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		26C552F754BE182B85CF33FD /* Pods-MultisigTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MultisigTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MultisigTests/Pods-MultisigTests.release.xcconfig"; sourceTree = "<group>"; };
 		3F3EDABD33C5D8D6E66ABA0E /* libPods-Multisig.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Multisig.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		551DDEE8244F183500C719D3 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		551DDEED244F19AE00C719D3 /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
+		551DDEEF244F1A0A00C719D3 /* SafeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeTests.swift; sourceTree = "<group>"; };
+		551DDEF1244F1B9800C719D3 /* AppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsTests.swift; sourceTree = "<group>"; };
 		5532D4922448A1960067505A /* Safe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Safe.swift; sourceTree = "<group>"; };
 		5532D4AF2449A17D0067505A /* CrashlyticsProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashlyticsProtocol.swift; sourceTree = "<group>"; };
 		5532D4B02449A17D0067505A /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -217,6 +225,7 @@
 		0A93DD6F2445CC8C00688050 /* MultisigTests */ = {
 			isa = PBXGroup;
 			children = (
+				551DDEEA244F192300C719D3 /* Models */,
 				5532D4E52449A5120067505A /* IntegrationTests */,
 				5532D4C42449A1980067505A /* Logger */,
 				5556A03924489F5D003EC861 /* Persistence */,
@@ -325,8 +334,18 @@
 		0AF432D5244F075800E22E50 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				551DDEE8244F183500C719D3 /* AppSettings.swift */,
 				5532D4922448A1960067505A /* Safe.swift */,
 				5556A03524489F37003EC861 /* Multisig.xcdatamodeld */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		551DDEEA244F192300C719D3 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				551DDEEF244F1A0A00C719D3 /* SafeTests.swift */,
+				551DDEF1244F1B9800C719D3 /* AppSettingsTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -413,6 +432,7 @@
 			children = (
 				5556A03A24489F5D003EC861 /* CoreDataStackTests.swift */,
 				5556A03B24489F5D003EC861 /* TestCoreDataStack.swift */,
+				551DDEED244F19AE00C719D3 /* CoreDataTestCase.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -599,6 +619,7 @@
 				5532D4BA2449A17D0067505A /* CrashlyticsProtocol.swift in Sources */,
 				5532D4C02449A17D0067505A /* ConsoleLogger.swift in Sources */,
 				0A93DDAE2446062F00688050 /* SafeSelector.swift in Sources */,
+				551DDEE9244F183500C719D3 /* AppSettings.swift in Sources */,
 				0A0256262449F90300C91D73 /* AddressInput.swift in Sources */,
 				0AF432C9244DFA9700E22E50 /* AddressInputSourceSheet.swift in Sources */,
 				0A93DD592445CC8A00688050 /* SceneDelegate.swift in Sources */,
@@ -626,10 +647,13 @@
 				5532D4CD2449A1980067505A /* LogServiceTests.swift in Sources */,
 				5532D4CA2449A1980067505A /* CrashlyticsLoggerTests.swift in Sources */,
 				5532D4CE2449A1980067505A /* ConsoleLoggerTests.swift in Sources */,
+				551DDEEE244F19AE00C719D3 /* CoreDataTestCase.swift in Sources */,
 				5532D4CB2449A1980067505A /* LoggableErrorTests.swift in Sources */,
+				551DDEF2244F1B9800C719D3 /* AppSettingsTests.swift in Sources */,
 				5532D4E42449A4FC0067505A /* SafeRelayServiceIntegrationTests.swift in Sources */,
 				5532D4DE2449A34A0067505A /* TestUtils.swift in Sources */,
 				5556A03C24489F5D003EC861 /* CoreDataStackTests.swift in Sources */,
+				551DDEF0244F1A0A00C719D3 /* SafeTests.swift in Sources */,
 				5532D4D12449A1E40067505A /* MockLogger.swift in Sources */,
 				5556A03D24489F5D003EC861 /* TestCoreDataStack.swift in Sources */,
 				5532D4CC2449A1980067505A /* LogFormatterTests.swift in Sources */,

--- a/Multisig/Logic/Models/AppSettings.swift
+++ b/Multisig/Logic/Models/AppSettings.swift
@@ -1,0 +1,36 @@
+//
+//  AppSettings.swift
+//  Multisig
+//
+//  Created by Andrey Scherbovich on 20.04.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+extension AppSettings {
+    public override func awakeFromInsert() {
+        super.awakeFromInsert()
+        self.createdAt = Date()
+    }
+
+    // MARK: - Fetch Requests
+
+    static func settings() -> NSFetchRequest<AppSettings> {
+        let request: NSFetchRequest<AppSettings> = AppSettings.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \AppSettings.createdAt, ascending: true)]
+        request.fetchLimit = 1
+        return request
+    }
+
+    // MARK: - Manipulating entities
+
+    static func getOrCreate(
+        context: NSManagedObjectContext = CoreDataStack.shared.persistentContainer.viewContext) -> AppSettings {
+        guard let settings = try? context.fetch(settings()), !settings.isEmpty else {
+            return AppSettings(context: context)
+        }
+        return settings[0]
+    }
+}

--- a/Multisig/Logic/Models/Multisig.xcdatamodeld/Multisig.xcdatamodel/contents
+++ b/Multisig/Logic/Models/Multisig.xcdatamodeld/Multisig.xcdatamodel/contents
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E266" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="AppSettings" representedClassName="AppSettings" syncable="YES" codeGenerationType="class">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="selectedSafe" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="Safe" representedClassName="Safe" syncable="YES" codeGenerationType="class">
         <attribute name="address" optional="YES" attributeType="String"/>
         <attribute name="confirmationsRequired" attributeType="Integer 64" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="contractVersion" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="ensName" optional="YES" attributeType="String"/>
         <attribute name="fallbackHandler" optional="YES" attributeType="String"/>
         <attribute name="masterCopyAddress" optional="YES" attributeType="String"/>
@@ -11,6 +16,7 @@
         <attribute name="nonce" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <elements>
-        <element name="Safe" positionX="-63" positionY="-18" width="128" height="163"/>
+        <element name="Safe" positionX="-63" positionY="-18" width="128" height="178"/>
+        <element name="AppSettings" positionX="-54" positionY="54" width="128" height="73"/>
     </elements>
 </model>

--- a/Multisig/Logic/Models/Safe.swift
+++ b/Multisig/Logic/Models/Safe.swift
@@ -10,11 +10,23 @@ import Foundation
 import CoreData
 
 extension Safe {
+    public override func awakeFromInsert() {
+        super.awakeFromInsert()
+        self.createdAt = Date()
+    }
+
+    // MARK: - Fetch Requests
 
     static func allSafes() -> NSFetchRequest<Safe> {
         let request: NSFetchRequest<Safe> = Safe.fetchRequest()
-        request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \Safe.createdAt, ascending: true)]
         return request
     }
 
+    static func by(address: String) -> NSFetchRequest<Safe> {
+        let request: NSFetchRequest<Safe> = Safe.fetchRequest()
+        request.predicate = NSPredicate(format: "address == %@", address)
+        request.fetchLimit = 1
+        return request
+    }
 }

--- a/MultisigTests/Models/AppSettingsTests.swift
+++ b/MultisigTests/Models/AppSettingsTests.swift
@@ -1,0 +1,25 @@
+//
+//  AppSettingsTests.swift
+//  MultisigTests
+//
+//  Created by Andrey Scherbovich on 21.04.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+class AppSettingsTests: CoreDataTestCase {
+    func test_settings_alwaysReturnsLastRecord() throws {
+        createAppSettings(selectedSafe: "one")
+        createAppSettings(selectedSafe: "two")
+        let result = try context.fetch(AppSettings.settings())
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].selectedSafe, "one")
+    }
+
+    private func createAppSettings(selectedSafe: String?) {
+        let appSettings = AppSettings(context: context)
+        appSettings.selectedSafe = selectedSafe
+    }
+}

--- a/MultisigTests/Models/SafeTests.swift
+++ b/MultisigTests/Models/SafeTests.swift
@@ -1,0 +1,38 @@
+//
+//  SafeTests.swift
+//  MultisigTests
+//
+//  Created by Andrey Scherbovich on 21.04.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+class SafeTests: CoreDataTestCase {
+    func test_allSafes() throws {
+        let safe0 = createSafe(name: "1")
+        let safe1 = createSafe(name: "0")
+        let result = try context.fetch(Safe.allSafes())
+        XCTAssertEqual(result.count, 2)
+        // should be sorted by creation date
+        XCTAssertEqual(result[0], safe0)
+        XCTAssertEqual(result[1], safe1)
+    }
+
+    func test_safeBy() throws {
+        let safe = createSafe(name: "0")
+        safe.address = "0x0"
+        createSafe(name: "1")
+        let result = try context.fetch(Safe.by(address: "0x0"))
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0], safe)
+    }
+
+    @discardableResult
+    private func createSafe(name: String) -> Safe {
+        let safe = Safe(context: context)
+        safe.name = name
+        return safe
+    }
+}

--- a/MultisigTests/Persistence/CoreDataStackTests.swift
+++ b/MultisigTests/Persistence/CoreDataStackTests.swift
@@ -10,14 +10,7 @@ import XCTest
 import CoreData
 @testable import Multisig
 
-class CoreDataStackTests: XCTestCase {
-    let coreDataStack = TestCoreDataStack()
-    var context: NSManagedObjectContext!
-
-    override func setUpWithError() throws {
-        context = coreDataStack.persistentContainer.viewContext
-    }
-
+class CoreDataStackTests: CoreDataTestCase {
     func testCRUD() throws {
         // check that initially all Safes are empty
         let initialSafesResult = try context.fetch(Safe.allSafes())
@@ -44,9 +37,9 @@ class CoreDataStackTests: XCTestCase {
         // Without saving the context, fetch request should be updated
         let twoSafesResultBeforeSave = try context.fetch(Safe.allSafes())
         XCTAssertEqual(twoSafesResultBeforeSave.count, 2)
-        // result safes should be sorted by name
-        XCTAssertEqual(twoSafesResultBeforeSave[0].name, "Safe 0")
-        XCTAssertEqual(twoSafesResultBeforeSave[1].name, "Safe 1")
+        // result safes should be sorted by creation date
+        XCTAssertEqual(twoSafesResultBeforeSave[0].name, "Safe 1")
+        XCTAssertEqual(twoSafesResultBeforeSave[1].name, "Safe 0")
 
         // reset context; not saved object is discarded
         context.reset()
@@ -63,5 +56,4 @@ class CoreDataStackTests: XCTestCase {
         let oneSafeResultAfterDeleting = try context.fetch(Safe.allSafes())
         XCTAssertEqual(oneSafeResultAfterDeleting.count, 0)
     }
-
 }

--- a/MultisigTests/Persistence/CoreDataTestCase.swift
+++ b/MultisigTests/Persistence/CoreDataTestCase.swift
@@ -1,0 +1,19 @@
+//
+//  CoreDataTestCase.swift
+//  MultisigTests
+//
+//  Created by Andrey Scherbovich on 21.04.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+import CoreData
+
+class CoreDataTestCase: XCTestCase {
+    let coreDataStack = TestCoreDataStack()
+    var context: NSManagedObjectContext!
+
+    override func setUpWithError() throws {
+        context = coreDataStack.persistentContainer.viewContext
+    }
+}


### PR DESCRIPTION
Please pay attention to AppSettings.getOrCreate() method. Here I have some open questions:

1) Should we use model entity extension to provide methods that create/return NSManagedObject (like AppSettings in our case) at all?

2) Or would you prefer to have these methods in a separate class like SafesController? 

If yes, should we save context immediately, or should it be done by the caller at some point?
I was implementing the "save_and_select_safe" method but later figured out that it might be confusing to select not persisted yet safe. 
So I think that it makes sense to give to a caller (logic layer) responsibility to create/persist/link/revert concrete entities. (option 3)

3) Or would it be ok not to have these methods at all and let logic layer to create/link/save/revert entities (NSManagedObject) with a granular control?

