### PR TITLE
Gh 229/unit test erc20 - batch 1

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		0A19D431249A4C5100A316B6 /* MethodSignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19D430249A4C5100A316B6 /* MethodSignatureTests.swift */; };
 		0A19D433249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19D432249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift */; };
 		0A19D435249A557E00A316B6 /* MethodRegistryTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19D434249A557E00A316B6 /* MethodRegistryTestCase.swift */; };
+		0A19D439249A5B1500A316B6 /* addOwnerWithThreshold_tx.json in Resources */ = {isa = PBXBuildFile; fileRef = 0A19D438249A5B1500A316B6 /* addOwnerWithThreshold_tx.json */; };
+		0A19D43B249A5BA500A316B6 /* addOwnerWithThreshold_safe.json in Resources */ = {isa = PBXBuildFile; fileRef = 0A19D43A249A5BA500A316B6 /* addOwnerWithThreshold_safe.json */; };
 		0A3F34DB2477E4E900E872AF /* KeyboardAdaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3F34D82477E4E900E872AF /* KeyboardAdaptive.swift */; };
 		0A465C2E246C196900AFA467 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A465C2D246C196900AFA467 /* Theme.swift */; };
 		0A465C32246C229800AFA467 /* FrameForNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A465C31246C229800AFA467 /* FrameForNavigationBar.swift */; };
@@ -322,6 +324,8 @@
 		0A19D430249A4C5100A316B6 /* MethodSignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSignatureTests.swift; sourceTree = "<group>"; };
 		0A19D432249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MethodRegistry+ERC20Tests.swift"; sourceTree = "<group>"; };
 		0A19D434249A557E00A316B6 /* MethodRegistryTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodRegistryTestCase.swift; sourceTree = "<group>"; };
+		0A19D438249A5B1500A316B6 /* addOwnerWithThreshold_tx.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = addOwnerWithThreshold_tx.json; sourceTree = "<group>"; };
+		0A19D43A249A5BA500A316B6 /* addOwnerWithThreshold_safe.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = addOwnerWithThreshold_safe.json; sourceTree = "<group>"; };
 		0A35CC2F24810CF6005E45BA /* ExportOptions.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ExportOptions.plist; sourceTree = "<group>"; };
 		0A3F34D82477E4E900E872AF /* KeyboardAdaptive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardAdaptive.swift; sourceTree = "<group>"; };
 		0A465C2D246C196900AFA467 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -721,6 +725,16 @@
 				5532D4DD2449A34A0067505A /* TestUtils.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		0A19D43C249A5BF100A316B6 /* Transaction */ = {
+			isa = PBXGroup;
+			children = (
+				0AA9F25824992CB6005BD60F /* TransactionTests.swift */,
+				0A19D43A249A5BA500A316B6 /* addOwnerWithThreshold_safe.json */,
+				0A19D438249A5B1500A316B6 /* addOwnerWithThreshold_tx.json */,
+			);
+			path = Transaction;
 			sourceTree = "<group>";
 		};
 		0A465C35246C23E800AFA467 /* Frame */ = {
@@ -1213,7 +1227,7 @@
 				0A0EFC9E246EADC200D3D8BF /* DisplayURLTests.swift */,
 				0ACC4C4D247534EC00ADF201 /* GnosisSafeTests.swift */,
 				55B66E8D24810BC800249E98 /* AppSettingsTests.swift */,
-				0AA9F25824992CB6005BD60F /* TransactionTests.swift */,
+				0A19D43C249A5BF100A316B6 /* Transaction */,
 				0A19D434249A557E00A316B6 /* MethodRegistryTestCase.swift */,
 				0A19D430249A4C5100A316B6 /* MethodSignatureTests.swift */,
 				0A19D432249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift */,
@@ -1524,6 +1538,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A19D43B249A5BA500A316B6 /* addOwnerWithThreshold_safe.json in Resources */,
+				0A19D439249A5B1500A316B6 /* addOwnerWithThreshold_tx.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -72,6 +72,9 @@
 		0A106285248A84F700C1EE54 /* SafeRelayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A106284248A84F700C1EE54 /* SafeRelayService.swift */; };
 		0A106287248A885E00C1EE54 /* ERC20Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A106286248A885D00C1EE54 /* ERC20Metadata.swift */; };
 		0A106289248A892B00C1EE54 /* ERC721Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A106288248A892B00C1EE54 /* ERC721Metadata.swift */; };
+		0A19D431249A4C5100A316B6 /* MethodSignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19D430249A4C5100A316B6 /* MethodSignatureTests.swift */; };
+		0A19D433249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19D432249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift */; };
+		0A19D435249A557E00A316B6 /* MethodRegistryTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19D434249A557E00A316B6 /* MethodRegistryTestCase.swift */; };
 		0A3F34DB2477E4E900E872AF /* KeyboardAdaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3F34D82477E4E900E872AF /* KeyboardAdaptive.swift */; };
 		0A465C2E246C196900AFA467 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A465C2D246C196900AFA467 /* Theme.swift */; };
 		0A465C32246C229800AFA467 /* FrameForNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A465C31246C229800AFA467 /* FrameForNavigationBar.swift */; };
@@ -316,6 +319,9 @@
 		0A106284248A84F700C1EE54 /* SafeRelayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeRelayService.swift; sourceTree = "<group>"; };
 		0A106286248A885D00C1EE54 /* ERC20Metadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ERC20Metadata.swift; sourceTree = "<group>"; };
 		0A106288248A892B00C1EE54 /* ERC721Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC721Metadata.swift; sourceTree = "<group>"; };
+		0A19D430249A4C5100A316B6 /* MethodSignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSignatureTests.swift; sourceTree = "<group>"; };
+		0A19D432249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MethodRegistry+ERC20Tests.swift"; sourceTree = "<group>"; };
+		0A19D434249A557E00A316B6 /* MethodRegistryTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodRegistryTestCase.swift; sourceTree = "<group>"; };
 		0A35CC2F24810CF6005E45BA /* ExportOptions.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ExportOptions.plist; sourceTree = "<group>"; };
 		0A3F34D82477E4E900E872AF /* KeyboardAdaptive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardAdaptive.swift; sourceTree = "<group>"; };
 		0A465C2D246C196900AFA467 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -1208,6 +1214,9 @@
 				0ACC4C4D247534EC00ADF201 /* GnosisSafeTests.swift */,
 				55B66E8D24810BC800249E98 /* AppSettingsTests.swift */,
 				0AA9F25824992CB6005BD60F /* TransactionTests.swift */,
+				0A19D434249A557E00A316B6 /* MethodRegistryTestCase.swift */,
+				0A19D430249A4C5100A316B6 /* MethodSignatureTests.swift */,
+				0A19D432249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1848,10 +1857,13 @@
 				5532D4DE2449A34A0067505A /* TestUtils.swift in Sources */,
 				5556A03C24489F5D003EC861 /* CoreDataStackTests.swift in Sources */,
 				551DDEF0244F1A0A00C719D3 /* SafeTests.swift in Sources */,
+				0A19D433249A4E0500A316B6 /* MethodRegistry+ERC20Tests.swift in Sources */,
 				5532D4CC2449A1980067505A /* LogFormatterTests.swift in Sources */,
 				0ACC4C4E247534EC00ADF201 /* GnosisSafeTests.swift in Sources */,
 				047300FE24781081004F1200 /* AddressTests.swift in Sources */,
 				0A9BC34A246053AD00EB9C5D /* ENSContractsTests.swift in Sources */,
+				0A19D435249A557E00A316B6 /* MethodRegistryTestCase.swift in Sources */,
+				0A19D431249A4C5100A316B6 /* MethodSignatureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Multisig/Logic/Models/Transaction/MethodRegistry+ERC20.swift
+++ b/Multisig/Logic/Models/Transaction/MethodRegistry+ERC20.swift
@@ -44,9 +44,9 @@ extension MethodRegistry {
             }
         }
 
+        #warning("TODO: tx.contractInfo.type == ContractInfoType.ERC20")
         static func isValid(_ tx: Transaction) -> Bool {
-            #warning("TODO: tx.contractInfo.type == ContractInfoType.ERC20")
-            return tx.operation == .call &&
+            tx.operation == .call &&
                 tx.dataDecoded != nil &&
                 (Transfer(data: tx.dataDecoded!) != nil ||
                     TransferFrom(data: tx.dataDecoded!) != nil)

--- a/Multisig/Logic/Models/Transaction/MethodRegistry.swift
+++ b/Multisig/Logic/Models/Transaction/MethodRegistry.swift
@@ -11,7 +11,7 @@ import Foundation
 /// A namespace for value types representing methods of smart contracts
 enum MethodRegistry {
 
-    struct MethodSignature {
+    struct MethodSignature: Hashable {
         var name: String
         var parameterTypes: [String]
 

--- a/Multisig/Logic/Models/Transaction/Transaction.swift
+++ b/Multisig/Logic/Models/Transaction/Transaction.swift
@@ -10,38 +10,37 @@ import Foundation
 
 // Information about structure described in https://github.com/gnosis/safe/issues/324
 struct Transaction: Decodable, Hashable {
-
     var safe: AddressString?
-    let to: AddressString?
-    let value: UInt256String?
-    let data: DataString?
-    let operation: GnosisSafeOperation?
-    let gasToken: AddressString?
-    let safeTxGas: UInt256String?
-    let baseGas: UInt256String?
-    let gasPrice: UInt256String?
-    let refundReceiver: AddressString?
-    let nonce: UInt256String?
-    let executionDate: Date?
-    let submissionDate: Date?
-    let modified: Date?
-    let blockNumber: UInt256String?
-    let transactionHash: DataString?
-    let safeTxHash: DataString?
-    let executor: AddressString?
-    let isExecuted: Bool?
-    let isSuccessful: Bool?
-    let tokenAddress: AddressString?
-    let ethGasPrice: UInt256String?
-    let gasUsed: UInt256String?
-    let fee: UInt256String?
-    let origin: String?
-    let dataDecoded: TransactionData?
-    let confirmationsRequired: UInt256String?
-    let confirmations: [TransactionConfirmation]?
-    let signatures: DataString?
-    let transfers: [TransactionTransfer]?
-    let txType: TransactionType?
+    var to: AddressString?
+    var value: UInt256String?
+    var data: DataString?
+    var operation: GnosisSafeOperation?
+    var gasToken: AddressString?
+    var safeTxGas: UInt256String?
+    var baseGas: UInt256String?
+    var gasPrice: UInt256String?
+    var refundReceiver: AddressString?
+    var nonce: UInt256String?
+    var executionDate: Date?
+    var submissionDate: Date?
+    var modified: Date?
+    var blockNumber: UInt256String?
+    var transactionHash: DataString?
+    var safeTxHash: DataString?
+    var executor: AddressString?
+    var isExecuted: Bool?
+    var isSuccessful: Bool?
+    var tokenAddress: AddressString?
+    var ethGasPrice: UInt256String?
+    var gasUsed: UInt256String?
+    var fee: UInt256String?
+    var origin: String?
+    var dataDecoded: TransactionData?
+    var confirmationsRequired: UInt256String?
+    var confirmations: [TransactionConfirmation]?
+    var signatures: DataString?
+    var transfers: [TransactionTransfer]?
+    var txType: TransactionType?
 }
 
 enum TransactionType: String, Decodable {

--- a/Multisig/Logic/Models/Transaction/TransactionData.swift
+++ b/Multisig/Logic/Models/Transaction/TransactionData.swift
@@ -13,17 +13,16 @@ struct TransactionData: Decodable, Hashable {
     let parameters: [TransactionDataParameter]
 }
 
-struct TransactionDataParameter: Decodable, Hashable {
+struct TransactionDataParameter: Hashable {
     let name: String
     let type: String
     let value: String?
+}
+
+extension TransactionDataParameter: Decodable {
 
     enum CodingKeys: CodingKey {
         case name, type, value
-    }
-
-    init(name: String, type: String, value: String?) {
-        (self.name, self.type, self.value) = (name, type, value)
     }
 
     init(from decoder: Decoder) throws {

--- a/Multisig/Logic/Models/Transaction/TransactionData.swift
+++ b/Multisig/Logic/Models/Transaction/TransactionData.swift
@@ -22,6 +22,10 @@ struct TransactionDataParameter: Decodable, Hashable {
         case name, type, value
     }
 
+    init(name: String, type: String, value: String?) {
+        (self.name, self.type, self.value) = (name, type, value)
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)

--- a/Multisig/UI/Assets/TokenBalance.swift
+++ b/Multisig/UI/Assets/TokenBalance.swift
@@ -14,7 +14,7 @@ struct TokenBalance: Identifiable, Hashable {
         address
     }
     var imageURL: URL? {
-        // will be replaced when https://github.com/gnosis/safe-transaction-service/issues/86 is ready
+        #warning("will be replaced when https://github.com/gnosis/safe-transaction-service/issues/86 is ready")
         return URL(string: "https://gnosis-safe-token-logos.s3.amazonaws.com/\(String(describing: address)).png")!
     }
     let address: String

--- a/MultisigTests/Logic/Models/MethodRegistry+ERC20Tests.swift
+++ b/MultisigTests/Logic/Models/MethodRegistry+ERC20Tests.swift
@@ -1,0 +1,159 @@
+//
+//  MethodRegistry+ERC20Tests.swift
+//  MultisigTests
+//
+//  Created by Dmitry Bespalov on 17.06.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+class MethodRegistry_ERC20Tests: MethodRegistryTestCase {
+
+    var validTransferData: TransactionData!
+    var validTransferFromData: TransactionData!
+
+    override func setUp() {
+        super.setUp()
+        validTransferData = txData((
+            "valid transfer() data",
+            "transfer", [
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "1")]))
+
+        validTransferFromData = txData((
+        "valid transferFrom() data",
+        "transferFrom", [
+            ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+            ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+            ("value", "uint256", "3")]))
+    }
+
+    func testTransferValidInputs() {
+        let call = MethodRegistry.ERC20.Transfer(data: validTransferData)
+        XCTAssertEqual(call?.to, "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488")
+        XCTAssertEqual(call?.amount, 1)
+    }
+
+    func testTransferFromValidInputs() {
+        let call = MethodRegistry.ERC20.TransferFrom(data: validTransferFromData)
+        XCTAssertEqual(call?.from, "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66")
+        XCTAssertEqual(call?.to, "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488")
+        XCTAssertEqual(call?.amount, 3)
+    }
+
+    func testTransferInvalidInputs() {
+        let dataSet: [RawTxData] = [
+            ("invalid method name",
+             "transfer123", [
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid address value",
+             "transfer", [
+                ("to", "address", "invalid addres"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid address's type",
+             "transfer", [
+                ("to", "address_???", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid amount type",
+             "transfer", [
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "xxx", "1") ]),
+
+            ("invalid amount value",
+             "transfer", [
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "some value") ]),
+
+            ("less arguments than needed",
+             "transfer", [
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488") ]),
+
+            ("more arguments than needed",
+             "transfer", [
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "1"),
+                ("value2", "uint256", "2") ]),
+        ]
+
+        for data in dataSet {
+            XCTAssertNil(MethodRegistry.ERC20.Transfer(data: txData(data)), "Data: \(data)")
+        }
+    }
+
+    func testTransferFromInvalidInputs() {
+        let dataSet: [RawTxData] = [
+
+            ("invalid method name",
+             "transferFrom123", [
+                ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid first address value",
+             "transferFrom", [
+                ("from", "address", "invalid addres"),
+                ("to", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid rist addess's type",
+             "transferFrom", [
+                ("from", "address_???", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("to", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid second address value",
+             "transferFrom", [
+                ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("to", "address", "invalid addres"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid second addess's type",
+             "transferFrom", [
+                ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("to", "address_???", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "1") ]),
+
+            ("invalid amount type",
+             "transferFrom", [
+                ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "xxx", "1") ]),
+
+            ("invalid amount value",
+             "transferFrom", [
+                ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "some value") ]),
+
+            ("less arguments than needed",
+             "transferFrom", [
+                ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488") ]),
+
+            ("more arguments than needed",
+             "transferFrom", [
+                ("from", "address", "0xaD86EecCbaC5e47848649936cf1efE78D56b1F66"),
+                ("to", "address", "0x37d037a9b66a323fBD38E9e2ae65e04C7C049488"),
+                ("value", "uint256", "1"),
+                ("value2", "uint256", "2") ]),
+        ]
+
+        for data in dataSet {
+            XCTAssertNil(MethodRegistry.ERC20.TransferFrom(data: txData(data)), "Data: \(data)")
+        }
+    }
+
+    func testIsValidTransfer() {
+        XCTAssertTrue(MethodRegistry.ERC20.isValid(Transaction(operation: .call, dataDecoded: validTransferData)))
+        XCTAssertTrue(MethodRegistry.ERC20.isValid(Transaction(operation: .call, dataDecoded: validTransferFromData)))
+        XCTAssertFalse(MethodRegistry.ERC20.isValid(Transaction(operation: .delegateCall, dataDecoded: validTransferData)))
+        XCTAssertFalse(MethodRegistry.ERC20.isValid(Transaction(operation: .call, dataDecoded: nil)))
+    }
+
+}

--- a/MultisigTests/Logic/Models/MethodRegistryTestCase.swift
+++ b/MultisigTests/Logic/Models/MethodRegistryTestCase.swift
@@ -1,0 +1,22 @@
+//
+//  MethodRegistryTestCase.swift
+//  MultisigTests
+//
+//  Created by Dmitry Bespalov on 17.06.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+class MethodRegistryTestCase: XCTestCase {
+
+    typealias RawTxData = (label: String, method: String, params: [(name: String, type: String, value: String?)])
+
+    func txData(_ d: RawTxData) -> TransactionData {
+        TransactionData(
+            method: d.method,
+            parameters: d.params.map(TransactionDataParameter.init(name:type:value:))  )
+    }
+
+}

--- a/MultisigTests/Logic/Models/MethodSignatureTests.swift
+++ b/MultisigTests/Logic/Models/MethodSignatureTests.swift
@@ -1,0 +1,39 @@
+//
+//  MethodSignatureTests.swift
+//  MultisigTests
+//
+//  Created by Dmitry Bespalov on 17.06.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+class MethodSignatureTests: MethodRegistryTestCase {
+
+    func testInit() {
+        let empty = MethodRegistry.MethodSignature("empty")
+        XCTAssertEqual(empty.name, "empty")
+        XCTAssertEqual(empty.parameterTypes, [])
+
+        let one = MethodRegistry.MethodSignature("test", "one")
+        XCTAssertEqual(one.name, "test")
+        XCTAssertEqual(one.parameterTypes, ["one"])
+
+        let many = MethodRegistry.MethodSignature("many", "one", "two", "three")
+        XCTAssertEqual(many.name, "many")
+        XCTAssertEqual(many.parameterTypes, ["one", "two", "three"])
+    }
+
+    func testEquality() {
+        let data = txData((
+            "equality with method signature",
+            "method", [
+                ("one", "O", "1"),
+                ("two", "T", "2"),
+                ("three", "H", nil)
+        ]))
+        let sig = MethodRegistry.MethodSignature("method", "O", "T", "H")
+        XCTAssertTrue(data == sig)
+    }
+}

--- a/MultisigTests/Logic/Models/Transaction/TransactionTests.swift
+++ b/MultisigTests/Logic/Models/Transaction/TransactionTests.swift
@@ -1,0 +1,47 @@
+//
+//  TransactionTests.swift
+//  MultisigTests
+//
+//  Created by Dmitry Bespalov on 16.06.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+class TransactionTests: XCTestCase {
+
+    func jsonData(_ name: String) -> Data {
+        try! Data(contentsOf: Bundle(for: Self.self).url(forResource: name, withExtension: "json")!)
+    }
+
+    func testAddOwner() {
+        let txJson = jsonData("addOwnerWithThreshold_tx")
+        let infoJson = jsonData("addOwnerWithThreshold_safe")
+
+        let sema = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            do {
+                let service = SafeTransactionService(url: App.configuration.services.transactionServiceURL, logger: LogService.shared)
+
+                let page = try service.jsonDecoder.decode(TransactionsRequest.Response.self, from: txJson)
+                let info = try service.jsonDecoder.decode(SafeStatusRequest.Response.self, from: infoJson)
+                let models = page.results.flatMap { tx in TransactionViewModel.create(from: tx, info) }
+                XCTAssertEqual(page.results.count, models.count)
+
+                guard let tx = models.first as? SettingChangeTransactionViewModel else {
+                    XCTFail("Unexpected type: \(type(of: models.first))")
+                    sema.signal()
+
+                    return
+                }
+
+                XCTAssertEqual(tx.title, MethodRegistry.GnosisSafeSettings.AddOwnerWithThreshold.signature.name)
+            } catch {
+                XCTFail("Failure in transactions: \(error)")
+            }
+            sema.signal()
+        }
+        sema.wait()
+    }
+}

--- a/MultisigTests/Logic/Models/Transaction/addOwnerWithThreshold_safe.json
+++ b/MultisigTests/Logic/Models/Transaction/addOwnerWithThreshold_safe.json
@@ -1,0 +1,15 @@
+{
+  "address": "0xaE3c91c89153DEaC332Ab7BBd167164978638c30",
+  "nonce": 49,
+  "threshold": 2,
+  "owners": [
+    "0x39cBD3814757Be997040E51921e8D54618278A08",
+    "0x37ec10a601dA5FF8bA6f87f40EA3e8F3E50c7f18",
+    "0x0e329fa8d6Fcd1ba0Cda495431F1f7CA24F442C2"
+  ],
+  "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+  "modules": [],
+  "fallbackHandler": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+  "version": "1.1.1"
+}
+

--- a/MultisigTests/Logic/Models/Transaction/addOwnerWithThreshold_tx.json
+++ b/MultisigTests/Logic/Models/Transaction/addOwnerWithThreshold_tx.json
@@ -1,19 +1,3 @@
-//
-//  TransactionTests.swift
-//  MultisigTests
-//
-//  Created by Dmitry Bespalov on 16.06.20.
-//  Copyright © 2020 Gnosis Ltd. All rights reserved.
-//
-
-import XCTest
-@testable import Multisig
-
-#warning("TODO: refactor and add more tests")
-class TransactionTests: XCTestCase {
-
-    func testAddOwner() {
-        let txJson = """
 {
 "count": 59,
 "next": "https://safe-transaction.staging.gnosisdev.com/api/v1/safes/0xaE3c91c89153DEaC332Ab7BBd167164978638c30/all-transactions/?limit=20&offset=20",
@@ -75,50 +59,4 @@ class TransactionTests: XCTestCase {
       "txType": "MULTISIG_TRANSACTION"
     }
   ]
-}
-"""
-        .data(using: .utf8)!
-        let infoJson = """
-{
-  "address": "0xaE3c91c89153DEaC332Ab7BBd167164978638c30",
-  "nonce": 49,
-  "threshold": 2,
-  "owners": [
-    "0x39cBD3814757Be997040E51921e8D54618278A08",
-    "0x37ec10a601dA5FF8bA6f87f40EA3e8F3E50c7f18",
-    "0x0e329fa8d6Fcd1ba0Cda495431F1f7CA24F442C2"
-  ],
-  "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
-  "modules": [],
-  "fallbackHandler": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
-  "version": "1.1.1"
-}
-"""
-        .data(using: .utf8)!
-
-        let sema = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
-            do {
-                let service = SafeTransactionService(url: App.configuration.services.transactionServiceURL, logger: LogService.shared)
-
-                let page = try service.jsonDecoder.decode(TransactionsRequest.Response.self, from: txJson)
-                let info = try service.jsonDecoder.decode(SafeStatusRequest.Response.self, from: infoJson)
-                let models = page.results.flatMap { tx in TransactionViewModel.create(from: tx, info) }
-                XCTAssertEqual(page.results.count, models.count)
-
-                guard let tx = models.first as? SettingChangeTransactionViewModel else {
-                    XCTFail("Unexpected type: \(type(of: models.first))")
-                    sema.signal()
-
-                    return
-                }
-
-                XCTAssertEqual(tx.title, MethodRegistry.GnosisSafeSettings.AddOwnerWithThreshold.signature.name)
-            } catch {
-                XCTFail("Failure in transactions: \(error)")
-            }
-            sema.signal()
-        }
-        sema.wait()
-    }
 }

--- a/MultisigTests/Logic/Models/TransactionTests.swift
+++ b/MultisigTests/Logic/Models/TransactionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Multisig
 
+#warning("TODO: refactor and add more tests")
 class TransactionTests: XCTestCase {
 
     func testAddOwner() {


### PR DESCRIPTION
Unit tests, batch number 1.

Remember the "var" vs. "let" discussion? Now I hit this wall: if you use "let", the struct doesn't let you (pun intended) to have generated initializer with just the properties you need, ignoring all nil properties - you have to provide all properties that are declared as "let". So I changed to "var".