### PR TITLE
gh-233  restricted adding safe

### DIFF
--- a/Multisig/Logic/Ethereum/GnosisSafe.swift
+++ b/Multisig/Logic/Ethereum/GnosisSafe.swift
@@ -20,8 +20,11 @@ class GnosisSafe {
         ("0xAC6072986E985aaBE7804695EC2d8970Cf7541A2", "0.0.2"),
         ("0x8942595A2dC5181Df0465AF0D7be08c8f23C93af", "0.1.0"),
         ("0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A", "1.0.0"),
+        ("0xaE32496491b53841efb51829d6f886387708F99B", "1.1.0"),
         ("0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F", "1.1.1")
     ]
+
+    var supportedVersions: [String] = ["1.0.0", "1.1.0", "1.1.1"]
 
     var fallbackHandlers:[(fallbackHandler: Address, label: String)] = [("0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44", "DefaultFallbackHandler")]
 
@@ -50,4 +53,10 @@ class GnosisSafe {
         versions.first { $0.masterCopy == masterCopy }?.version
     }
 
+    func isSupported(_ masterCopy: Address) -> Bool {
+        guard let version = versionNumber(masterCopy: masterCopy) else {
+            return false
+        }
+        return supportedVersions.contains(version)
+    }
 }

--- a/MultisigTests/Logic/Models/GnosisSafeTests.swift
+++ b/MultisigTests/Logic/Models/GnosisSafeTests.swift
@@ -36,4 +36,31 @@ class GnosisSafeTests: XCTestCase {
         XCTAssertEqual(safe.version(masterCopy: someAddress), .unknown)
     }
 
+    func testSupportedVersions() {
+        let supported: [Address] = [
+            "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A",
+            "0xaE32496491b53841efb51829d6f886387708F99B",
+            "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+        ]
+
+        let notSupported: [Address] = [
+            "0xAC6072986E985aaBE7804695EC2d8970Cf7541A2",
+            "0x8942595A2dC5181Df0465AF0D7be08c8f23C93af",
+        ]
+
+        let unknown: [Address] = [
+            "0x3b1c2b0940C85458197E0D18690805d6F89547eE",
+            "0x976DC99c50B916Ea9b5275979059BCe9f1A0B1D1",
+            "0xD5D4763AE65aFfFD82e3aEe3ec9f21171A1d6e0e",
+        ]
+
+        for v in supported {
+            XCTAssertTrue(safe.isSupported(v), "Expected to support \(v)")
+        }
+
+        for v in notSupported + unknown {
+            XCTAssertFalse(safe.isSupported(v), "Expected NOT to support \(v)")
+        }
+    }
+
 }


### PR DESCRIPTION
I've restricted **adding** safe with unsupported versions, but *having* a safe with unsupported version is *OK*, imo 👍 In case we drop support for some version in the future, people would still be able to see the safe settings.